### PR TITLE
Localized strings (en-gb, ja-jp, he-il) for the Update working-with-comments.md pull request on wassemgtk-patch-57

### DIFF
--- a/aaa/xxx/yyyy/en/zzz/GB/working-with-comments.md
+++ b/aaa/xxx/yyyy/en/zzz/GB/working-with-comments.md
@@ -1,0 +1,119 @@
+---
+title: Working with Comments
+---
+
+
+{:toc}
+
+For any Pull Request, {{ site.data.variables.product.product_name }} provides three kinds of comment views:
+[comments on the Pull Request][PR comment] as a whole, [comments on a specific line][PR line comment] within the Pull Request,
+and [comments on a specific commit][commit comment] within the Pull Request.
+
+Each of these types of comments goes through a different portion of the {{ site.data.variables.product.product_name }} API.
+In this guide, we'll explore how you can access and manipulate each one. For every
+example, we'll be using [this sample Pull Request made][sample PR] on the "octocat"
+repository. As always, samples can be found in [our platform-samples repository][platform-samples].
+
+## Pull Request Comments
+
+To access comments on a Pull Request, you'll go through [the Issues API][issues].
+This may seem counterintuitive at first. But once you understand that a Pull
+Request is just an Issue with code, it makes sense to use the Issues API to
+create comments on a Pull Request.
+
+We'll demonstrate fetching Pull Request comments by creating a Ruby script using
+[Octokit.rb][octokit.rb]. You'll also want to create a [personal access token][personal token].
+
+The following code should help you get started accessing comments from a Pull Request
+using Octokit.rb:
+
+``` ruby
+require 'octokit'
+
+# !!! DO NOT EVER USE HARD-CODED VALUES IN A REAL APP !!!
+# Instead, set and test environment variables, like below
+client = Octokit::Client.new :access_token => ENV['MY_PERSONAL_TOKEN']
+
+client.issue_comments("octocat/Spoon-Knife", 1176).each do |comment|
+username = comment[:user][:login]
+post_date = comment[:created_at]
+content = comment[:body]
+
+puts "#{username} made a comment on #{post_date}. It says:\n'#{content}'\n"
+# end
+```
+
+Here, we're specifically calling out to the Issues API to get the comments (`issue_comments`),
+providing both the repository's name (`octocat/Spoon-Knife`), and the Pull Request ID
+we're interested in (`1176`). After that, it's simply a matter of iterating through
+the comments to fetch information about each one.
+
+## Pull Request Comments on a Line
+
+Within the diff view, you can start a discussion on a particular aspect of a singular
+change made within the Pull Request. These comments occur on the individual lines
+within a changed file. The endpoint URL for this discussion comes from [the Pull Request Review API][PR Review API].
+
+The following code fetches all the Pull Request comments made on files, given a single Pull Request number:
+
+``` ruby
+require 'octokit'
+
+# !!! DO NOT EVER USE HARD-CODED VALUES IN A REAL APP !!!
+# Instead, set and test environment variables, like below
+client = Octokit::Client.new :access_token => ENV['MY_PERSONAL_TOKEN']
+
+client.pull_request_comments("octocat/Spoon-Knife", 1176).each do |comment|
+username = comment[:user][:login]
+post_date = comment[:created_at]
+content = comment[:body]
+path = comment[:path]
+position = comment[:position]
+
+puts "#{username} made a comment on #{post_date} for the file called #{path}, on line #{position}. It says:\n'#{content}'\n"
+# end
+```
+
+You'll notice that it's incredibly similar to the example above. The difference
+between this view and the Pull Request comment is the focus of the conversation.
+A comment made on a Pull Request should be reserved for discussion or ideas on
+the overall direction of the code. A comment made as part of a Pull Request review should
+deal specifically with the way a particular change was implemented within a file.
+
+## Commit Comments
+
+The last type of comments occur specifically on individual commits. For this reason,
+they make use of [the commit comment API][commit comment API].
+
+To retrieve the comments on a commit, you'll want to use the SHA1 of the commit.
+In other words, you won't use any identifier related to the Pull Request. Here's an example:
+
+``` ruby
+require 'octokit'
+
+# !!! DO NOT EVER USE HARD-CODED VALUES IN A REAL APP !!!
+# Instead, set and test environment variables, like below
+client = Octokit::Client.new :access_token => ENV['MY_PERSONAL_TOKEN']
+
+client.commit_comments("octocat/Spoon-Knife", "cbc28e7c8caee26febc8c013b0adfb97a4edd96e").each do |comment|
+username = comment[:user][:login]
+post_date = comment[:created_at]
+content = comment[:body]
+
+puts "#{username} made a comment on #{post_date}. It says:\n'#{content}'\n"
+# end
+```
+
+Note that this API call will retrieve single line comments, as well as comments made
+on the entire commit.
+
+[PR comment]: https://github.com/octocat/Spoon-Knife/pull/1176#issuecomment-24114792
+[PR line comment]: https://github.com/octocat/Spoon-Knife/pull/1176#discussion_r6252889
+[commit comment]: https://github.com/octocat/Spoon-Knife/commit/cbc28e7c8caee26febc8c013b0adfb97a4edd96e#commitcomment-4049848
+[sample PR]: https://github.com/octocat/Spoon-Knife/pull/1176
+[platform-samples]: https://github.com/github/platform-samples/tree/master/api/ruby/working-with-comments
+[issues]: https://developer.github.com/v3/issues/comments/
+[personal token]: https://help.github.com/articles/creating-an-access-token-for-command-line-use
+[octokit.rb]: https://github.com/octokit/octokit.rb
+[PR Review API]: https://developer.github.com/v3/pulls/comments/
+[commit comment API]: https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment

--- a/aaa/xxx/yyyy/he/zzz/IL/working-with-comments.md
+++ b/aaa/xxx/yyyy/he/zzz/IL/working-with-comments.md
@@ -1,0 +1,119 @@
+---
+כותרת: עבודה עם תגובות
+---
+
+
+{:toc}
+
+לכל בקשה Pull, {{ site.data.variables.product.product_name }} מספקת שלושה סוגים של תצוגות תגובה:
+[comments on the Pull Request][PR comment] בכללותו, [comments on a specific line][PR line comment] בתוך בקשת Pull,
+ו [comments on a specific commit][commit comment] בתוך הבקשה למשוך.
+
+כל הסוגים הללו של הערות עובר חלק אחר של API {{ site.data.variables.product.product_name }}.
+במדריך זה, אנו נחקור איך אתה יכול לגשת ולטפל בכל אחד. לכל
+למשל, אנחנו נשתמש [this sample Pull Request made][sample PR] על "octocat"
+מאגר. כמו תמיד, ניתן למצוא דגימות ב [our platform-samples repository][platform-samples].
+
+## תגובות בקשת Pull
+
+כדי לגשת הערות על בקשת Pull, תצטרך לעבור [the Issues API][issues].
+זה אולי נראה מנוגד בהתחלה. אבל ברגע שאתה מבין כי Pull
+בקשה אינה רק בעיה עם קוד, זה הגיוני להשתמש ב- API התכנים
+ליצור הערות על בקשה למשוך.
+
+נצטרך להפגין מקסים הערות בקשה משוך על ידי יצירת סקריפט רובי באמצעות
+[Octokit.rb][octokit.rb]. מומלץ גם ליצור [personal access token][personal token].
+
+הקוד הבא אמור לעזור לך להתחיל בגישת הערות מבקשה Pull
+באמצעות Octokit.rb:
+
+`` `אודם
+דורש "octokit"
+
+# !!! אין להשתמש EVER ערכים בקידוד קשיח ב- App אמיתי !!!
+# במקום, להגדיר סביבת הבדיקה משתנים, כמו בדוגמא הבאה
+לקוח = Octokit :: Client.new: ACCESS_TOKEN => ENV['MY_PERSONAL_TOKEN']
+
+client.issue_comments ( "octocat / Spoon-סכין", 1176) .each לעשות | תגובה |
+שם המשתמש = comment[:user][:login]
+post_date = comment[:created_at]
+תוכן = comment[:body]
+
+מכניס "# {username} העיר הערה על # {post_date} זה אומר: \n '# {content}'\n"
+סוף
+```
+
+הנה, אנחנו קוראים את ספציפי ל- API הסוגיות כדי לקבל את ההערות ( `issue_comments`),
+מתן גם את השם של המאגר ( `octocat / Spoon-Knife`), ואת זהות בקשת Pull
+אנחנו מתעניינים ( `1176`). אחרי זה, זה פשוט עניין של ולביקורות דרך
+ההערות להביא מידע על כל אחד.
+
+## תגובות בקשה משוך על קו
+
+מתוך תצוגת ההבדל, אתה יכול להתחיל דיון על היבט מסוים של יחיד
+לשנות שנעשה בתוך הבקשה למשוך. הערות אלה מתרחשות על הקווים הפרט
+בתוך קובץ שונה. כתובת האתר Endpoint של הדיון הזה מגיע [the Pull Request Review API][PR Review API].
+
+הקוד הבא מביא את כל הערות בקשת Pull שנעשו על קבצים, קבל מספר בקשת Pull יחיד:
+
+`` `אודם
+דורש "octokit"
+
+# !!! אין להשתמש EVER ערכים בקידוד קשיח ב- App אמיתי !!!
+# במקום, להגדיר סביבת הבדיקה משתנים, כמו בדוגמא הבאה
+לקוח = Octokit :: Client.new: ACCESS_TOKEN => ENV['MY_PERSONAL_TOKEN']
+
+client.pull_request_comments ( "octocat / Spoon-סכין", 1176) .each לעשות | תגובה |
+שם המשתמש = comment[:user][:login]
+post_date = comment[:created_at]
+תוכן = comment[:body]
+נתיב = comment[:path]
+עמדה = comment[:position]
+
+מכניס "# {username} העיר הערה על # {post_date} עבור קובץ שנקרא # {path}, על קו # {position} זה אומר: \n '# {content}'\n"
+סוף
+```
+
+תוכל להבחין שזה מאוד דומה בדוגמה לעיל. ההבדל
+בין השקפה זו לבין תגובת בקשת Pull הוא מוקד השיחה.
+הוסיף הערה על בקשת Pull צריכה להיות שמורה דיון או רעיונות
+הכיוון הכללי של הקוד. לתגובה שפורסמה כחלק מבקש סקירת Pull צריך
+לטפל ספציפית דרך שינוי מסוים יושם בתוך קובץ.
+
+## להתחייב תגובות
+
+הסוג האחרון של הערות להתרחש דווקא על תתחייב פרט. מהסיבה הזו,
+הם עושים שימוש [the commit comment API][commit comment API].
+
+כדי לאחזר את ההערות על להתחייב, אתה תרצה להשתמש SHA1 של להתחייב.
+במילים אחרות, לא תוכל להשתמש בכל מזהה המתייחסים לבקשה למשוך. הנה דוגמה:
+
+`` `אודם
+דורש "octokit"
+
+# !!! אין להשתמש EVER ערכים בקידוד קשיח ב- App אמיתי !!!
+# במקום, להגדיר סביבת הבדיקה משתנים, כמו בדוגמא הבאה
+לקוח = Octokit :: Client.new: ACCESS_TOKEN => ENV['MY_PERSONAL_TOKEN']
+
+client.commit_comments ( "octocat / Spoon-סכין", "cbc28e7c8caee26febc8c013b0adfb97a4edd96e") כל לעשות |. תגובה |
+שם המשתמש = comment[:user][:login]
+post_date = comment[:created_at]
+תוכן = comment[:body]
+
+מכניס "# {username} העיר הערה על # {post_date} זה אומר: \n '# {content}'\n"
+סוף
+```
+
+שים לב API שיחה זו תהיה לאחזר תגובות שורה אחת, כמו גם דבריו
+על כל להתחייב.
+
+[PR comment]: https://github.com/octocat/Spoon-Knife/pull/1176#issuecomment-24114792
+[PR line comment]: https://github.com/octocat/Spoon-Knife/pull/1176#discussion_r6252889
+[commit comment]: https://github.com/octocat/Spoon-Knife/commit/cbc28e7c8caee26febc8c013b0adfb97a4edd96e#commitcomment-4049848
+[sample PR]: https://github.com/octocat/Spoon-Knife/pull/1176
+[platform-samples]: https://github.com/github/platform-samples/tree/master/api/ruby/working-with-comments
+[issues]: https://developer.github.com/v3/issues/comments/
+[personal token]: https://help.github.com/articles/creating-an-access-token-for-command-line-use
+[octokit.rb]: https://github.com/octokit/octokit.rb
+[PR Review API]: https://developer.github.com/v3/pulls/comments/
+[commit comment API]: https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment

--- a/aaa/xxx/yyyy/ja/zzz/JP/working-with-comments.md
+++ b/aaa/xxx/yyyy/ja/zzz/JP/working-with-comments.md
@@ -1,0 +1,119 @@
+---
+タイトル：コメントでの作業
+---
+
+
+{：TOC} __ v__
+
+任意のプル要求については、コメント・ビューの3種類が用意されています。 {{ site.data.variables.product.product_name }}
+[comments on the Pull Request][PR comment]プル要求の中で、全体として、 [comments on a specific line] [PR line comment]
+そして [comments on a specific commit][commit comment]、プル要求内。
+
+コメントのこれらの各タイプ は、APIの異なる部分を通過します。 {{ site.data.variables.product.product_name }}
+このガイドでは、我々はあなたがそれぞれ1にアクセスして操作する方法を見ていきます。すべてのための
+例えば、私たちは「octocat」に使うことになるでしょう [this sample Pull Request made] [sample PR]
+リポジトリ。いつものように、サンプルはで見つけることができます。 [our platform-samples repository] [platform-samples]
+
+##プルリクエストコメント
+
+プルリクエストのコメントにアクセスするには、を介して行きますよ。 [the Issues API] [issues]
+これは、最初は直感に反するように見えるかもしれません。しかし、あなたはそのプルを理解すれば
+要求は、それが問題のAPIを使用することは理にかなって、コードでだけの問題であり、
+##リストは、プル要求にコミット
+
+我々は、使用して、Rubyスクリプトを作成することによって、プルリクエストのコメントを取り出す説明します
+[Octokit.rb][octokit.rb]。また、作成したいと思うでしょう。 [personal access token] [personal token]
+
+次のコードは、プルリクエストからのコメントへのアクセス始めるのに役立つ必要があります
+Octokit.rb使用しました：
+
+`` `ルビー
+「octokit 'を必要と
+
+＃!!! EVER REALアプリでハードコードされた値は、使用しないでください！
+＃その代わりに、以下のように、変数を設定し、テスト環境
+@client || = Octokit :: Octokit::Client.new（：access_tokenは=> access_tokenは） ['MY_PERSONAL_TOKEN']
+
+行う.each client.issue_comments（「octocat /スプーン・ナイフ」、, 1176).each年）|コメント|
+ユーザ名= comment[:user][:login]
+post_date = comment[:created_at]
+コンテンツ= comment[:body]
+
+プット "＃の{username}は＃の{post_date}にコメントをしたことは言う：。\n '＃の{content}'\n"
+終わり
+```
+
+ここでは、具体的には、コメント（ `issue_comments`）を取得するための問題APIに出て呼んでいます
+リポジトリの名前（ `octocat /スプーン-Knife`）、およびプルリクエストIDの両方を提供
+我々は（ `1176`）に興味を持っています。その後、それは単にを反復処理の問題です
+コメントは各1についての情報を取得します。
+
+##リストは、プル要求にコミット
+
+差分ビュー内では、単数形の特定の側面についての議論を開始することができます
+プルリクエスト内で行われた変更。これらのコメントは、個々の行で発生します
+変更されたファイル内。この議論のためのエンドポイントURLがから来ています。 [the Pull Request Review API] [PR Review API]
+
+次のコードは、単一のプルリクエスト番号与えられたファイルに行われたすべてのプル要求のコメントを、フェッチ：
+
+`` `ルビー
+「octokit 'を必要と
+
+＃!!! EVER REALアプリでハードコードされた値は、使用しないでください！
+＃その代わりに、以下のように、変数を設定し、テスト環境
+@client || = Octokit :: Octokit::Client.new（：access_tokenは=> access_tokenは） ['MY_PERSONAL_TOKEN']
+
+行う.each client.issue_comments（「octocat /スプーン・ナイフ」、, 1176).each年）|コメント|
+ユーザ名= comment[:user][:login]
+post_date = comment[:created_at]
+コンテンツ= comment[:body]
+パス= comment[:path]
+位置= comment[:position]
+
+プット "＃の{username}は、ライン＃1 {position}に、＃1 {path}と呼ばれるファイルのための＃1 {post_date}にコメントをしたことは言う：。\n '＃の{content}'\n"
+終わり
+```
+
+あなたはそれが上記の例と非常に似ていることに気づくでしょう。違い
+このビューとプルリクエストのコメントの間の会話の焦点です。
+プルリクエストで行われたコメントは、議論やアイデアにするために予約する必要があります
+コードの全体的な方向性。プル要求の見直しの一環として作られたコメントすべきです
+特定の変更がファイル内に実装された方法と特異的に対処します。
+
+##コメントをコミット
+
+コメントの最後のタイプは、個々のコミットに特異的に発生します。このために、
+彼らが利用しています。 [the commit comment API] [commit comment API]
+
+コミットのコメントを取得するには、コミットのSHA1を使用したいと思います。
+言い換えれば、あなたは、プル要求に関連する任意の識別子を使用しません。次に例を示します。
+
+`` `ルビー
+「octokit 'を必要と
+
+＃!!! EVER REALアプリでハードコードされた値は、使用しないでください！
+＃その代わりに、以下のように、変数を設定し、テスト環境
+@client || = Octokit :: Octokit::Client.new（：access_tokenは=> access_tokenは） ['MY_PERSONAL_TOKEN']
+
+Client.commit_comments（「octocat /スプーン・ナイフ "、" cbc28e7c8caee26febc8c013b0adfb97a4edd96e」）それぞれん|。コメント|
+ユーザ名= comment[:user][:login]
+post_date = comment[:created_at]
+コンテンツ= comment[:body]
+
+プット "＃の{username}は＃の{post_date}にコメントをしたことは言う：。\n '＃の{content}'\n"
+終わり
+```
+
+このAPIコールは、単一の行のコメントを取得することに注意してください、と同様のコメント
+全体にコミットします。
+
+[PR comment]：https://github.com/octocat/Spoon-Knife/pull/1176#issuecomment-24114792
+[PR line comment]：https://github.com/octocat/Spoon-Knife/pull/1176#discussion_r6252889
+[commit comment]：https://github.com/octocat/Spoon-Knife/commit/cbc28e7c8caee26febc8c013b0adfb97a4edd96e#commitcomment-4049848
+[sample PR]：https://github.com/octocat/Spoon-Knife/pull/1176
+[platform-samples]：https://github.com/github/platform-samples/tree/master/api/ruby/working-with-comments
+[issues]：https://developer.github.com/v3/issues/comments/
+[personal token]：https://help.github.com/articles/creating-an-access-token-for-command-line-use
+[octokit.rb]：https://github.com/octokit/octokit.rb
+[PR Review API]：https://developer.github.com/v3/pulls/comments/
+[commit comment API]：https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment


### PR DESCRIPTION
ja-jp | content/guides/working-with-comments.md | 119 strings

en-gb | content/guides/working-with-comments.md | 119 strings

he-il | content/guides/working-with-comments.md | 119 strings
 
 cc @wassemgtk